### PR TITLE
Add a getCallerFileInfo overload that accepts an exception

### DIFF
--- a/src/main/kotlin/filepeek/FilePeek.kt
+++ b/src/main/kotlin/filepeek/FilePeek.kt
@@ -15,10 +15,10 @@ class FilePeek(
     private val ignoredPackages: List<String> = emptyList(),
     private val sourceRoots: List<String> = listOf("src${FS}test${FS}kotlin", "src${FS}test${FS}java")
 ) {
+    fun getCallerFileInfo() = getCallerFileInfo(RuntimeException())
 
-    fun getCallerFileInfo(
-    ): FileInfo {
-        val stackTrace = RuntimeException().stackTrace
+    fun getCallerFileInfo(ex: Throwable): FileInfo {
+        val stackTrace = ex.stackTrace
 
         val callerStackTraceElement = stackTrace.first { el ->
             ignoredPackages


### PR DESCRIPTION
Building the exception is relatively cheap, but reading the stack trace is costly. This overload supports the case of capturing the stack trace, but delaying reading the stack trace until needed.